### PR TITLE
Fix for modify source string after `^` method

### DIFF
--- a/src/mrb_string_xor.c
+++ b/src/mrb_string_xor.c
@@ -26,6 +26,7 @@ string_xor(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "string length does not match");
   }
   s = mrb_str_dup(mrb, self);
+  mrb_str_modify(mrb, RSTRING(s));
   p = RSTRING_PTR(s);
   p2 = RSTRING_PTR(str2);
   pend = RSTRING_END(s);

--- a/test/mrb_string_xor.rb
+++ b/test/mrb_string_xor.rb
@@ -1,3 +1,5 @@
 assert("String#^(other)") do
-  assert_equal("\0" * 12, 'わーい！' ^ 'わーい！')
+  src = 'わーい！' * 3
+  assert_equal("\0" * src.bytesize, src ^ 'わーい！' * 3)
+  assert_equal(src, 'わーい！' * 3)
 end


### PR DESCRIPTION
Sorry for Japanese text.

`String#^` をした時に、出力文字列が共有化された文字列となる場合 `self` の内容まで変更されてしまいます。

```ruby
src = "a" * 30
p src ^ "a" * 30 # => "\x00" * 30
p src # => "\x00" * 30
```

文字列を書き換える処理の前に `mrb_str_modify()` が必要です。

手前勝手ながら、テストもちょっといじってしまいました。

`'わーい！' * 3` となっているのは、`MRB_STR_EMBED` な文字列にしないためです。

よろしくお願いします。