### PR TITLE
Add .xor_clamp and .xor_repeat

### DIFF
--- a/src/mrb_string_xor.c
+++ b/src/mrb_string_xor.c
@@ -37,11 +37,69 @@ string_xor(mrb_state *mrb, mrb_value self)
   return s;
 }
 
+static mrb_value
+string_xor_clamp(mrb_state *mrb, mrb_value self)
+{
+  mrb_value s, str2;
+  mrb_int len, len2;
+  char *p, *pend, *p2;
+
+  len = RSTRING_LEN(self);
+  mrb_get_args(mrb, "S", &str2);
+  s = mrb_str_dup(mrb, self);
+  mrb_str_modify(mrb, RSTRING(s));
+  p = RSTRING_PTR(s);
+  p2 = RSTRING_PTR(str2);
+  len2 = RSTRING_LEN(str2);
+  pend = p + (len < len2 ? len : len2);
+  while (p < pend) {
+    *p ^= *p2;
+    p++;
+    p2++;
+  }
+  return s;
+}
+
+static mrb_value
+string_xor_repeat(mrb_state *mrb, mrb_value self)
+{
+  mrb_value s, str2;
+  mrb_int len, len2;
+  char *p, *pend;
+  const char *p2, *p2tmp;
+  int i, j;
+
+  len = RSTRING_LEN(self);
+  mrb_get_args(mrb, "S", &str2);
+  s = mrb_str_dup(mrb, self);
+  mrb_str_modify(mrb, RSTRING(s));
+  p = RSTRING_PTR(s);
+  p2 = RSTRING_PTR(str2);
+  len2 = RSTRING_LEN(str2);
+  pend = RSTRING_END(s);
+  for (i = len / len2; i > 0; i--) {
+    p2tmp = p2;
+    for (j = len2; j > 0; j--) {
+      *p ^= *p2tmp;
+      p++;
+      p2tmp++;
+    }
+  }
+  while (p < pend) {
+    *p ^= *p2;
+    p++;
+    p2++;
+  }
+  return s;
+}
+
 void
 mrb_mruby_string_xor_gem_init(mrb_state* mrb)
 {
   struct RClass * s = mrb->string_class;
   mrb_define_method(mrb, s, "^", string_xor, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, s, "xor_clamp", string_xor_clamp, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, s, "xor_repeat", string_xor_repeat, MRB_ARGS_REQ(1));
   DONE;
 }
 

--- a/test/mrb_string_xor.rb
+++ b/test/mrb_string_xor.rb
@@ -1,3 +1,18 @@
 assert("String#^(other)") do
   assert_equal("\0" * 12, 'わーい！' ^ 'わーい！')
 end
+
+assert("String#xor_clamp") do
+  src = 'abcdefghijklmnopqrstuvwxyz' * 1 # duplicate unshared string
+  assert_equal('AbCdefghijklmnopqrstuvwxyz', src.xor_clamp("\x20\x00\x20"))
+  assert_equal('AbCDeFGhIJkLMnOpqrstuvwxyz', src.xor_clamp("\x20\x00\x20" * 5))
+  assert_equal('AbCDeFGhIJkLMnOPqRStUVwXYz', src.xor_clamp("\x20\x00\x20" * 100))
+  assert_equal('abcdefghijklmnopqrstuvwxyz', src)
+end
+
+assert("String#xor_repeat") do
+  src = 'abcdefghijklmnopqrstuvwxyz' * 1 # duplicate unshared string
+  assert_equal('AbCDeFGhIJkLMnOPqRStUVwXYz', src.xor_repeat("\x20\x00\x20"))
+  assert_equal('AbCDeFGhIJkLMnOPqRStUVwXYz', src.xor_repeat("\x20\x00\x20" * 100))
+  assert_equal('abcdefghijklmnopqrstuvwxyz', src)
+end


### PR DESCRIPTION
Sorry for Japanese text.

xor する文字列長が `self` と異なる場合の二つのメソッドを追加しました。

  * `String#xor_clamp` : 短い方の途中で打ち切る<br>
    ```ruby
    p "abcdefg".xor_clamp("\x02\x20\x02") # => "cBacdefg"
    ```
  * `String#xor_repeat` : `other` を巡回文字列として `self` の長さだけ処理する<br>
    ```ruby
    p "abcdefghijklmn".xor_repeat("\x02\x20\x02")' # => "cBafEdeHkhKnoN"
    ```

`clamp` と `repeat` は OpenGL のテクスチャ指定で使う `GL_CLAMP` `GL_REPEAT` から取っています。

よろしくお願いします。
